### PR TITLE
fix：ビルド時のprismaの初期化設定を追記.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
- ビルド時のprismaの初期化設定を追記
デプロイメント時に最新のPrisma Clientを生成（キャッシュの影響を排除）