### PR TITLE
fix:過去コンテンツを判定する日付比較の条件と、予約内容編集後の再編集時の挙動を修正.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,29 @@
 - [Vercel Postgres](https://vercel.com/docs/storage/vercel-postgres)
 - [Vercel Postgres Pricing](https://vercel.com/docs/storage/vercel-postgres/usage-and-pricing)
 
+### Vercel / prisma
+1. `Vercel`に当該`GitHub`リポジトリをリンク（デプロイ）
+2. `Vercel`ダッシュボード内の[`Storage`]でデータベースを作成
+3. `prisma`の設定を行う
+ - Prismaのインストール（※インストールしていない場合）
+ ```
+ npm install prisma @prisma/client
+ npm install @prisma/client
+ ```
+ - Prismaの初期化
+ ```
+ npx prisma init
+ ```
+ - マイグレーションフォルダの生成
+ ```
+ npx prisma migrate dev --name init
+ ```
+ - クライアントの生成
+ ```
+ npx prisma generate
+ ```
+4. `.env`, `.env.local`の設定（詳細は[備考](#備考)）をはじめ、`Vercel`での環境変数の設定も行う
+
 ## 技術構成
 - @prisma/client@6.1.0
 - @types/node@20.16.11

--- a/src/app/components/schedule/calendar/Calendar.tsx
+++ b/src/app/components/schedule/calendar/Calendar.tsx
@@ -28,7 +28,7 @@ function Calendar() {
 
     const date: Date = new Date();
     const present: number = useMemo(() => {
-        return parseInt(`${date.getFullYear()}${(date.getMonth() + 1).toString().padStart(2, '0')}${date.getDate().toString().padStart(2, '0')}`);
+        return parseInt(`${date.getFullYear()}${(date.getMonth() + 1)}${date.getDate()}`);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/src/app/components/schedule/calendar/components/DaysList.tsx
+++ b/src/app/components/schedule/calendar/components/DaysList.tsx
@@ -22,7 +22,7 @@ function DaysList({ props }: { props: DaysListType }) {
     const { days, present } = props;
 
     const isNotPastDays: (day: calendarItemType) => boolean = (day: calendarItemType) => {
-        const dayDate: number = parseInt(`${day.year}${day.month.toString().padStart(2, '0')}${day.day.toString().padStart(2, '0')}`);
+        const dayDate: number = parseInt(`${day.year}${day.month}${day.day}`);
         return dayDate >= present;
     }
 

--- a/src/app/components/schedule/todoItems/TodoItems.tsx
+++ b/src/app/components/schedule/todoItems/TodoItems.tsx
@@ -7,11 +7,9 @@ import TodoItemsEditable from "./utils/TodoItemsEditable";
 import TodoItemsDisEditable from "./utils/TodoItemsDisEditable";
 import { useCloseModalWindow } from "./hooks/useCloseModalWindow";
 import { useScrollTop } from "@/app/hooks/useScrollTop";
-import { useUpdateTodoItem } from "./hooks/useUpdateTodoItem";
 
 function TodoItems({ todoItem }: { todoItem: todoItemType }) {
     const [todoMemo, setTodoMemo] = useAtom(todoMemoAtom);
-    const { updateReservation } = useUpdateTodoItem();
 
     const updateTodoMemoEditState: (editState: boolean) => void = (editState: boolean) => {
         const updateTodoList: todoItemType = {
@@ -27,11 +25,6 @@ function TodoItems({ todoItem }: { todoItem: todoItemType }) {
         const exceptUpdateTodoMemos: todoItemType[] = [...todoMemo].filter(todoMemoItem => todoMemoItem.id !== todoItem.id);
 
         setTodoMemo([...exceptUpdateTodoMemos, updateTodoList]);
-
-        // 編集画面の[戻る]ボタンを押下してパスワードロックした場合は DB の todoItem.edit を更新
-        if (updateTodoList.edit === false) {
-            updateReservation(updateTodoList);
-        }
     }
 
     const { closeModalWindow } = useCloseModalWindow();

--- a/src/app/components/schedule/todoItems/utils/TodoFormItemRegiBtn.tsx
+++ b/src/app/components/schedule/todoItems/utils/TodoFormItemRegiBtn.tsx
@@ -40,6 +40,15 @@ function TodoFormItemRegiBtn({ todoItems, resetStates }: {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [todoItems]);
 
+    // 編集後に edit:true のままだと誰でも編集できてしまうので false に上書き（＝再編集を行うには再度パスワード入力が必要となる）
+    const adjustEditState_updateTodoItem: (todoItems: todoItemType) => void = (todoItems: todoItemType) => {
+        const adjustEditStateTodoItems: todoItemType = {
+            ...todoItems,
+            edit: false
+        }
+        updateTodoItem(adjustEditStateTodoItems);
+    }
+
     return (
         <button className={todoStyle.formBtns} id={todoStyle.regiUpdateBtn}
             type="button"
@@ -56,7 +65,7 @@ function TodoFormItemRegiBtn({ todoItems, resetStates }: {
                     handleOpenClosedBtnClicked(btnEl.currentTarget);
                 } else {
                     btnEl.stopPropagation(); // 親要素のクリックイベント（OnViewModalWindow）発生を防止
-                    updateTodoItem(todoItems);
+                    adjustEditState_updateTodoItem(todoItems);
                     closeModalWindow();
                 }
                 resetStates();


### PR DESCRIPTION
- 過去コンテンツを判定する日付比較の条件
  - `src/app/components/schedule/calendar/Calendar.tsx`<br>過去コンテンツの削除判定に用いる日付（数値型）の桁数を修正
  - `src/app/components/schedule/calendar/components/DaysList.tsx`<br>予約登録機能（+アイコン）表示有無に用いる日付（数値型）の桁数を修正
  - `src/app/components/schedule/todoItems/TodoItems.tsx`<br>本修正に伴って不要となった更新処理を排除
- 予約内容編集後の再編集時の挙動を修正
  - `src/app/components/schedule/todoItems/utils/TodoFormItemRegiBtn.tsx`<br>編集後に`edit:true`のままだと誰でも編集できてしまうので`false`に上書き（＝再編集を行うには再度パスワード入力が必要となる）
- `README.md`<br>`Vercel`, `prisma`の設定フローを追記