### PR TITLE
fix: 予約可能期間の延長と関連調整作業、バリデーションテキストの表示順の修正.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 以下の仕様に関しては[reserve-sys-sqlite](https://github.com/Benjuwan/reserve-sys-sqlite)リポジトリと同様です。<br><br>
 
 - 予約内容の重複禁止<br>他の方が先に予約している場合は受け付けません。
-- 予約時間外は受付不可<br>今月かつ「`timeBlockBegin`時～`timeBlockEnd`時（※）」の時間帯で予約できます。また、タイムテーブルには当日分の予約内容が反映されます。<br>※：`src/app/types/rooms-atom.ts`の`timeBlockBegin`と`timeBlockEnd`から値を取得
+- 予約時間外は受付不可<br>「`timeBlockBegin`時～`timeBlockEnd`時（※）」の時間帯で予約できます。各部屋ごとのタイムテーブルには当日分の予約内容が反映されます。<br>※：`src/app/types/rooms-atom.ts`の`timeBlockBegin`と`timeBlockEnd`から値を取得
 - 過去の予約内容は随時削除<br>当日以前の過去予約内容は削除（※）されます。<br>※：`src/app/components/schedule/calendar/Calendar.tsx`内の`useEffect`での`deleteReservation`処理にて実行
 
 #### 予約方法

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -20,7 +20,7 @@ export default async function AboutPage() {
                     </div>
                     <div>
                         <dt>予約時間外は受付不可</dt>
-                        <dd>今月かつ「{timeBlockBegin}時～{timeBlockEnd}時」の時間帯で予約できます。また、タイムテーブルには当日分の予約内容が反映されます。</dd>
+                        <dd>「{timeBlockBegin}時～{timeBlockEnd}時」の時間帯で予約できます。各部屋ごとのタイムテーブルには当日分の予約内容が反映されます。</dd>
                     </div>
                     <div>
                         <dt>過去の予約内容は随時削除</dt>

--- a/src/app/components/schedule/todoItems/TodoCtrlOpenBtn.tsx
+++ b/src/app/components/schedule/todoItems/TodoCtrlOpenBtn.tsx
@@ -4,27 +4,18 @@ import todoStyle from "./styles/todoStyle.module.css";
 import { calendarItemType } from "../calendar/ts/calendarItemType";
 import { useScrollTop } from "@/app/hooks/useScrollTop";
 import { useViewTodoCtrl } from "./hooks/useViewTodoCtrl";
+import { useRestrictReservationTerm } from "./hooks/useRestrictReservationTerm";
 
 import add_circle from "../../../../../public/icons/add_circle.svg";
 
 function TodoCtrlOpenBtn({ day }: { day: calendarItemType }) {
-    const checkFutureMonthes: () => boolean = () => {
-        const date: Date = new Date();
-        const present: number = parseInt(`${date.getFullYear()}${(date.getMonth() + 1).toString().padStart(2, '0')}`);
-        const dayDate: number = parseInt(`${day.year}${day.month.toString().padStart(2, '0')}`);
-
-        return present < dayDate;
-    }
-
     const { scrollTop } = useScrollTop();
     const { viewTodoCtrl } = useViewTodoCtrl();
+    const { restrictReservationTerm } = useRestrictReservationTerm();
 
     const handleOpenClosedBtnClicked: (btnEl: HTMLButtonElement) => void = (btnEl: HTMLButtonElement) => {
-        const isCheckFutureMonthes: boolean = checkFutureMonthes();
-        if (isCheckFutureMonthes) {
-            const thisYear: number = new Date().getFullYear();
-            const thisMonth: number = new Date().getMonth() + 1;
-            alert(`今月（${thisYear}/${thisMonth}）しか予約できません`);
+        const isRestrictReservationTerm: boolean = restrictReservationTerm(day);
+        if (isRestrictReservationTerm) {
             return;
         }
 

--- a/src/app/components/schedule/todoItems/hooks/useCheckTimeValidation.ts
+++ b/src/app/components/schedule/todoItems/hooks/useCheckTimeValidation.ts
@@ -14,25 +14,25 @@ export const useCheckTimeValidation = () => {
             (typeof todoItems.startTime !== 'undefined' && typeof todoItems.finishTime !== 'undefined') &&
             typeof validationTxtRef !== 'undefined'
         ) {
-            const isCheckTimeBlockEntryForm_start: boolean = checkTimeBlockEntryForm(todoItems.startTime);
-            const isCheckTimeBlockEntryForm_finish: boolean = checkTimeBlockEntryForm(todoItems.finishTime);
-            if (isCheckTimeBlockEntryForm_start || isCheckTimeBlockEntryForm_finish) {
-                validationTxtRef.current = `「${timeBlockBegin}時〜${timeBlockEnd}時」の時間帯で指定してください`;
-            }
-
             const isCheckTimeSchedule_start: boolean = checkTimeSchedule(todoItems.startTime, todoItems);
             const isCheckTimeSchedule_finish: boolean = checkTimeSchedule(todoItems.finishTime, todoItems);
             if (isCheckTimeSchedule_start || isCheckTimeSchedule_finish) {
                 validationTxtRef.current = '他の方が既に予約済みです';
             }
 
-            const isCheckTimeBlockEntryForm_FALSE: boolean = !isCheckTimeBlockEntryForm_start && !isCheckTimeBlockEntryForm_finish;
+            const isCheckTimeBlockEntryForm_start: boolean = checkTimeBlockEntryForm(todoItems.startTime);
+            const isCheckTimeBlockEntryForm_finish: boolean = checkTimeBlockEntryForm(todoItems.finishTime);
+            if (isCheckTimeBlockEntryForm_start || isCheckTimeBlockEntryForm_finish) {
+                validationTxtRef.current = `「${timeBlockBegin}時〜${timeBlockEnd}時」の時間帯で指定してください`;
+            }
+
             const isCheckTimeSchedule_FALSE: boolean = !isCheckTimeSchedule_start && !isCheckTimeSchedule_finish;
+            const isCheckTimeBlockEntryForm_FALSE: boolean = !isCheckTimeBlockEntryForm_start && !isCheckTimeBlockEntryForm_finish;
 
             // バリデーションの初期化（ useCheckTimeBlockEntryForm の上記どちらの関数処理チェックも false かつ validationTxtRef が入力済みの場合）
             if (
-                isCheckTimeBlockEntryForm_FALSE &&
                 isCheckTimeSchedule_FALSE &&
+                isCheckTimeBlockEntryForm_FALSE &&
                 validationTxtRef.current.length > 0
             ) {
                 validationTxtRef.current = '';

--- a/src/app/components/schedule/todoItems/hooks/useRestrictReservationTerm.ts
+++ b/src/app/components/schedule/todoItems/hooks/useRestrictReservationTerm.ts
@@ -1,0 +1,28 @@
+import { calendarItemType } from "../../calendar/ts/calendarItemType";
+
+export const useRestrictReservationTerm = () => {
+    const restrictReservationTerm: (day: calendarItemType) => boolean = (day: calendarItemType) => {
+        const date: Date = new Date();
+        let ReservableTermYear: number = date.getFullYear();
+        let ReservableTermMonth: number = date.getMonth() + 7;
+
+        // 12月を超える場合は月と年を調整
+        if (ReservableTermMonth > 12) {
+            ReservableTermYear = date.getFullYear() + 1; // 翌年
+            ReservableTermMonth = ReservableTermMonth - 12; // 月を調整
+        }
+
+        const configReservableTerm_YearMonth: number = parseInt(`${ReservableTermYear}${(ReservableTermMonth).toString().padStart(2, '0')}`);
+        const dayDate: number = parseInt(`${day.year}${day.month.toString().padStart(2, '0')}`);
+
+        const isValidationReservable: boolean = configReservableTerm_YearMonth < dayDate;
+        if (isValidationReservable) {
+            alert(`6ヶ月以内（${ReservableTermYear}/${ReservableTermMonth}まで）が予約可能（受け付け）期間です。`);
+            return true;
+        }
+
+        return false;
+    }
+
+    return { restrictReservationTerm }
+}


### PR DESCRIPTION
- 予約可能期間の延長（半年先まで予約可能にした）と関連調整作業
  - `src/app/components/schedule/todoItems/TodoCtrlOpenBtn.tsx`<br>予約期間の検証処理を分離してコードリファクタリング
  - `src/app/components/schedule/todoItems/hooks/useRestrictReservationTerm.ts`<br>予約期間の検証処理のカスタムフック
  - 関連調整作業
    - `README.md`
    - `src/app/about/page.tsx`
- バリデーションテキストの表示順の修正
  - `src/app/components/schedule/todoItems/hooks/useCheckTimeValidation.ts`