### PR TITLE
fix: タイムテーブルの週間表示切替機能の不具合修正.

### DIFF
--- a/src/components/rooms/Rooms.tsx
+++ b/src/components/rooms/Rooms.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { memo, useEffect, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import roomStyle from "./styles/roomstyle.module.css";
 import { useAtom } from "jotai";
 import { roomsAtom, roomsInfoToolTipAtom } from "@/types/rooms-atom";
@@ -34,12 +34,8 @@ function Rooms() {
 
     const [roomsInfo] = useAtom(roomsInfoToolTipAtom);
 
-    /* 418 hydration-error 対策 */
-    const [today, setToday] = useState<number>(0);
-    useEffect(() => {
-        const today: number = new Date().getDate();
-        setToday(today);
-    }, []);
+    const today: number = useMemo(() => new Date().getDate(), []);
+    const [ctrlMultiTimeTable, setCtrlMultiTimeTable] = useState<number>(today);
 
     return (
         <section className={roomStyle.roomWrapper}>
@@ -50,8 +46,9 @@ function Rooms() {
                 }>{roomsInfo}</p>
             }
             <MultiTimeTableCtrlBtns props={{
-                today: today,
-                setToday: setToday
+                ctrlMultiTimeTable: ctrlMultiTimeTable,
+                setCtrlMultiTimeTable: setCtrlMultiTimeTable,
+                today: today
             }} />
             {rooms.map((room, i) => (
                 <div key={i} className={roomStyle.roomContainer}>
@@ -60,7 +57,7 @@ function Rooms() {
                         <TimeTable props={{
                             room: room.room,
                             todoMemo: todoMemo,
-                            today: today
+                            ctrlMultiTimeTable: ctrlMultiTimeTable
                         }} />
                     </div>
                 </div>

--- a/src/components/rooms/components/MultiTimeTableCtrlBtns.tsx
+++ b/src/components/rooms/components/MultiTimeTableCtrlBtns.tsx
@@ -3,18 +3,19 @@ import roomStyle from "../styles/roomstyle.module.css";
 import ViewCurrentTimeTableDay from "./ViewCurrentTimeTableDay";
 
 type ctrlBtnsProps = {
+    ctrlMultiTimeTable: number;
+    setCtrlMultiTimeTable: React.Dispatch<React.SetStateAction<number>>;
     today: number;
-    setToday: React.Dispatch<React.SetStateAction<number>>;
 };
 
 function MultiTimeTableCtrlBtns({ props }: { props: ctrlBtnsProps }) {
-    const { today, setToday } = props;
+    const { ctrlMultiTimeTable, setCtrlMultiTimeTable, today } = props;
 
     /* 418 hydration-error 対策 */
     const [thisLastDay, setThisLastDay] = useState<number>(0);
     useEffect(() => {
-        // 当年当月の「0日目」を取得（翌月の0日＝当月の最終日）し、その日付（最終日）を出す
-        // 例：const thisLastDay = new Date(2025, 6, 0).getDate()
+        // 当年当月の「0日目」を取得（翌月の0日＝当月の最終日）し、その日付（最終日）を出す 
+        // 例：const thisLastDay = new Date(2025, 6, 0).getDate() 
         const targetLastDay: number = new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0).getDate();
         setThisLastDay(targetLastDay);
     }, []);
@@ -37,11 +38,11 @@ function MultiTimeTableCtrlBtns({ props }: { props: ctrlBtnsProps }) {
             (oneWeekLater - thisLastDay === 0 && day > thisLastDay) ||
             day >= thisLastDay
         ) {
-            setToday(1);
+            setCtrlMultiTimeTable(1);
             return;
         }
 
-        setToday(prev => prev + 1);
+        setCtrlMultiTimeTable(prev => prev + 1);
     }
 
     // 前日のタイムテーブルを制御する関数
@@ -51,30 +52,30 @@ function MultiTimeTableCtrlBtns({ props }: { props: ctrlBtnsProps }) {
         }
 
         if (day === 1) {
-            setToday(thisLastDay);
+            setCtrlMultiTimeTable(thisLastDay);
             return;
         }
 
-        setToday(prev => prev - 1);
+        setCtrlMultiTimeTable(prev => prev - 1);
     }
 
     // ボタンのクリックイベントハンドラ（タイムテーブルの制御を担う）
-    const handletoday: (e: React.MouseEvent<HTMLButtonElement>) => void = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const handleCtrlMultiTimeTable: (e: React.MouseEvent<HTMLButtonElement>) => void = (e: React.MouseEvent<HTMLButtonElement>) => {
         const btnDataAttr: string = e.currentTarget.getAttribute('data-btn') ?? '';
         if (btnDataAttr === 'prev') {
-            ctrlPrevTimeTable(today);
+            ctrlPrevTimeTable(ctrlMultiTimeTable);
         } else if (btnDataAttr === 'next') {
-            ctrlNextTimeTable(today);
+            ctrlNextTimeTable(ctrlMultiTimeTable);
         }
     };
 
     return (
         <>
             <div className={roomStyle.multiTimeTableCtrlBtns}>
-                <button onClick={handletoday} data-btn="prev">&lt; 前日</button>
-                <button onClick={handletoday} data-btn="next">翌日 &gt;</button>
+                <button onClick={handleCtrlMultiTimeTable} data-btn="prev">&lt; 前日</button>
+                <button onClick={handleCtrlMultiTimeTable} data-btn="next">翌日 &gt;</button>
             </div>
-            <ViewCurrentTimeTableDay today={today} isLastWeek={isLastWeek} />
+            <ViewCurrentTimeTableDay ctrlMultiTimeTable={ctrlMultiTimeTable} isLastWeek={isLastWeek} />
         </>
     );
 }

--- a/src/components/rooms/components/TimeBlock.tsx
+++ b/src/components/rooms/components/TimeBlock.tsx
@@ -8,11 +8,11 @@ type TimeBlockType = {
     room: string;
     timeBlock: number;
     todoMemo: todoItemType[];
-    today: number;
+    ctrlMultiTimeTable: number;
 };
 
 function TimeBlock({ props }: { props: TimeBlockType }) {
-    const { room, timeBlock, todoMemo, today } = props;
+    const { room, timeBlock, todoMemo, ctrlMultiTimeTable } = props;
 
     const minBlocks: number[] = [];
     for (let i = 1; i <= 59; i++) minBlocks.push(i);
@@ -21,7 +21,7 @@ function TimeBlock({ props }: { props: TimeBlockType }) {
 
     const { hoverEventListener, leaveEventListener } = useCtrlToolTips();
 
-    const theTimeTableViewDay: string = useCreateTimeTableViewDay(today);
+    const theTimeTableViewDay: string = useCreateTimeTableViewDay(ctrlMultiTimeTable);
 
     // useMemo を使用した動的な予約情報（当日より1週間分の各部屋ごとのタイムテーブル配列）の取得 
     const relevantReservations: todoItemType[] = useMemo(() => {
@@ -30,7 +30,7 @@ function TimeBlock({ props }: { props: TimeBlockType }) {
             (typeof memo.rooms !== 'undefined' && memo.rooms === room)
         );
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [todoMemo, room, today]);
+    }, [todoMemo, room, ctrlMultiTimeTable]);
 
     return (
         <>

--- a/src/components/rooms/components/TimeTable.tsx
+++ b/src/components/rooms/components/TimeTable.tsx
@@ -7,11 +7,11 @@ import { todoItemType } from "../../schedule/todoItems/ts/todoItemType";
 type timeTableProps = {
     room: string;
     todoMemo: todoItemType[];
-    today: number;
+    ctrlMultiTimeTable: number;
 };
 
 function TimeTable({ props }: { props: timeTableProps }) {
-    const { room, todoMemo, today } = props;
+    const { room, todoMemo, ctrlMultiTimeTable } = props;
 
     const timeBlocks: number[] = [];
     for (let i = timeBlockBegin; i < timeBlockEnd; i++) timeBlocks.push(i);
@@ -26,7 +26,7 @@ function TimeTable({ props }: { props: timeTableProps }) {
                             room: room,
                             timeBlock: timeBlock,
                             todoMemo: todoMemo,
-                            today: today
+                            ctrlMultiTimeTable: ctrlMultiTimeTable
                         }} />
                     </div>
                 </li>

--- a/src/components/rooms/components/ViewCurrentTimeTableDay.tsx
+++ b/src/components/rooms/components/ViewCurrentTimeTableDay.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from "react";
 import { usePathname } from "next/navigation";
 
-function ViewCurrentTimeTableDay({ today, isLastWeek }: { today: number, isLastWeek: boolean }) {
+function ViewCurrentTimeTableDay({ ctrlMultiTimeTable, isLastWeek }: { ctrlMultiTimeTable: number, isLastWeek: boolean }) {
     const pathName: string = usePathname();
 
     const thisMonth: number = useMemo(() => new Date().getMonth() + 1, []);
@@ -9,7 +9,8 @@ function ViewCurrentTimeTableDay({ today, isLastWeek }: { today: number, isLastW
     return (
         <>
             {pathName.length === 1 &&
-                <p suppressHydrationWarning={true}>- <b>{isLastWeek && today <= 7 ? thisMonth + 1 : thisMonth}/{today}</b> の予約内容（※7日後まで確認可能）</p>
+                // [Minified React error #418 対応](https://react.dev/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors)
+                <p suppressHydrationWarning={true}>- <b>{isLastWeek && ctrlMultiTimeTable <= 7 ? thisMonth + 1 : thisMonth}/{ctrlMultiTimeTable}</b> の予約内容（※7日後まで確認可能）</p>
             }
         </>
     );


### PR DESCRIPTION
- タイムテーブルの週間表示切替機能の不具合修正
418ハイドレーションエラー対策によってリファクタリングしたことで、エラー解消したものの、代わりに週間表示の「前日への表示バック」が動かなくなり、７日後以降も表示されてしまうようになった。
そこで、要所と思わしきコンポーネントのみハイドレーションエラー対策を実施し、残りのファイルは内容を差し戻した。
  - ハイドレーションエラー対策を実施する要所と思わしきコンポーネント
    - `src/components/rooms/components/MultiTimeTableCtrlBtns.tsx`
  - 内容を差し戻したファイル
    - `src/components/rooms/Rooms.tsx`
    - `src/components/rooms/components/TimeBlock.tsx`
    - `src/components/rooms/components/TimeTable.tsx`
    - `src/components/rooms/components/ViewCurrentTimeTableDay.tsx`